### PR TITLE
[#1][#2][#3] 로그인 / 회원가입 페이지 요구사항 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="./public/todo.png" />
+		<link rel="icon" type="image/svg+xml" href="/todo.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Team12 - Assignment 1</title>
 	</head>

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
 		"prepare": "husky install"
 	},
 	"dependencies": {
+		"axios": "^1.1.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.4.2",
-		"styled-components": "^5.3.6"
+		"styled-components": "^5.3.6",
+		"styled-reset": "^4.4.2"
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.17",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
-function App() {
-	return <div className="App">Hello ~!</div>;
-}
+import Router from './router';
+
+const App = () => {
+	return <Router />;
+};
 
 export default App;

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,31 @@
+import { PATH, POST } from '../constants/api';
+import { UserAuthRequestDto, UserAuthResponseDto } from '../types/auth';
+import { requester } from './requester';
+
+export const signin = async (userAuthRequestBody: UserAuthRequestDto) => {
+	const {
+		auth: { index, signin },
+	} = PATH;
+
+	const { data } = await requester<UserAuthResponseDto>({
+		method: POST,
+		url: `${index}${signin}`,
+		data: userAuthRequestBody,
+	});
+
+	return data.access_token;
+};
+
+export const signup = async (userAuthRequestBody: UserAuthRequestDto) => {
+	const {
+		auth: { index, signup },
+	} = PATH;
+
+	const { data } = await requester<UserAuthResponseDto>({
+		method: POST,
+		url: `${index}${signup}`,
+		data: userAuthRequestBody,
+	});
+
+	return data.access_token;
+};

--- a/src/apis/requester.ts
+++ b/src/apis/requester.ts
@@ -1,0 +1,38 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { getLocalStorageItem, KEYS } from '../utils/storage';
+
+const createAxiosInstance = () => {
+	const base = axios.create({
+		baseURL: import.meta.env.VITE_BASE_API_URL,
+	});
+
+	return base;
+};
+
+const axiosInstance = createAxiosInstance();
+
+export async function requester<Payload>(option: AxiosRequestConfig) {
+	const ACCESS_TOKEN = getLocalStorageItem(KEYS.WANTED_ACCESS_TOKEN);
+	const response: AxiosResponse<Payload> = await axiosInstance(
+		ACCESS_TOKEN
+			? {
+					headers: {
+						Authorization: `Bearer ${ACCESS_TOKEN}`,
+						'Content-Type': 'application/json',
+					},
+					...option,
+			  }
+			: {
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					...option,
+			  },
+	);
+
+	return {
+		status: response.status,
+		headers: response.headers,
+		data: response.data,
+	};
+}

--- a/src/apis/todo.ts
+++ b/src/apis/todo.ts
@@ -1,0 +1,60 @@
+import { DELETE, GET, PATH, POST, PUT } from '../constants/api';
+import { Todo } from '../types/todo';
+import { requester } from './requester';
+
+export const createTodo = async (newTodo: string) => {
+	const {
+		todos: { index },
+	} = PATH;
+
+	const { data, status } = await requester<Todo>({
+		method: POST,
+		url: `${index}`,
+		data: { todo: newTodo },
+	});
+
+	return { status, data };
+};
+
+export const getTodos = async () => {
+	const {
+		todos: { index },
+	} = PATH;
+
+	const { data, status } = await requester<Todo[]>({
+		method: GET,
+		url: `${index}`,
+	});
+
+	return { status, data };
+};
+
+export const updateTodo = async (targetTodo: Todo, newTodo?: string) => {
+	const {
+		todos: { index },
+	} = PATH;
+
+	const { data, status } = await requester<Todo>({
+		method: PUT,
+		url: `${index}/${targetTodo.id}`,
+		data: {
+			todo: newTodo ?? targetTodo.todo,
+			isCompleted: newTodo ? targetTodo.isCompleted : !targetTodo.isCompleted,
+		},
+	});
+
+	return { status, data };
+};
+
+export const deleteTodo = async (targetTodo: Todo) => {
+	const {
+		todos: { index },
+	} = PATH;
+
+	const { data, status } = await requester({
+		method: DELETE,
+		url: `${index}/${targetTodo.id}`,
+	});
+
+	return { status, data };
+};

--- a/src/components/feature/AuthForm/index.tsx
+++ b/src/components/feature/AuthForm/index.tsx
@@ -1,0 +1,52 @@
+import * as S from './styled';
+import { InputWrapper, InputLabel, InputErrorMessage } from '../../shared/Input/styled';
+import { Input, Button } from '../../../components';
+import { AUTH_INPUT_ERROR_MESSAGE } from '../../../constants/error';
+import { UserAuthRequestDto } from '../../../types/auth';
+import useAuthForm from './useAuthForm';
+
+type Props = {
+	mode: 'signin' | 'signup';
+	onAuthFormSubmit: (userAuthRequestBody: UserAuthRequestDto) => void;
+};
+
+const AuthForm = (props: Props) => {
+	const { userAuthForm, onAuthFormChange, onAuthFormSubmitClick } = useAuthForm({
+		onAuthFormSubmit: props.onAuthFormSubmit,
+	});
+
+	return (
+		<S.Container onSubmit={onAuthFormSubmitClick}>
+			<InputWrapper margin="0 0 1em 0">
+				<InputLabel>이메일</InputLabel>
+				<Input
+					id="email"
+					type="text"
+					placeholder="이메일을 입력해주세요."
+					name="email"
+					value={userAuthForm.email.value}
+					onChange={onAuthFormChange}
+				/>
+				{userAuthForm.email.isNotValidate && <InputErrorMessage>{AUTH_INPUT_ERROR_MESSAGE.email}</InputErrorMessage>}
+			</InputWrapper>
+			<InputWrapper margin="0 0 3em 0">
+				<InputLabel>비밀번호</InputLabel>
+				<Input
+					id="password"
+					type="password"
+					placeholder="비밀번호를 입력해주세요."
+					name="password"
+					value={userAuthForm.password.value}
+					onChange={onAuthFormChange}
+				/>
+				{userAuthForm.password.isNotValidate && <InputErrorMessage>{AUTH_INPUT_ERROR_MESSAGE.password}</InputErrorMessage>}
+			</InputWrapper>
+
+			<Button type="submit" disabled={userAuthForm.email.isNotValidate || userAuthForm.password.isNotValidate}>
+				{props.mode === 'signin' ? '로그인' : '회원가입'}
+			</Button>
+		</S.Container>
+	);
+};
+
+export default AuthForm;

--- a/src/components/feature/AuthForm/styled.ts
+++ b/src/components/feature/AuthForm/styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Container = styled.form`
+	${({ theme }) => theme.layout.flexColumn};
+	flex: 1;
+	padding: 1.5em;
+`;

--- a/src/components/feature/AuthForm/useAuthForm.ts
+++ b/src/components/feature/AuthForm/useAuthForm.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { UserAuthForm, UserAuthRequestDto } from '../../../types/auth';
+
+type Props = {
+	onAuthFormSubmit: (userAuthRequestBody: UserAuthRequestDto) => void;
+};
+
+const useAuthForm = (props: Props) => {
+	const [userAuthForm, setUserAuthForm] = useState<UserAuthForm>({
+		email: { value: '', isNotValidate: true },
+		password: { value: '', isNotValidate: true },
+	});
+
+	const userAuthFormValidation = (userInfoForm: UserAuthForm) => {
+		const { email, password } = userInfoForm;
+
+		if (email.value.includes('@') && password.value.length >= 8) {
+			setUserAuthForm({ email: { ...email, isNotValidate: false }, password: { ...password, isNotValidate: false } });
+		} else if (!email.value.includes('@') && password.value.length >= 8) {
+			setUserAuthForm({ email: { ...email, isNotValidate: true }, password: { ...password, isNotValidate: false } });
+		} else if (email.value.includes('@') && password.value.length < 8) {
+			setUserAuthForm({ email: { ...email, isNotValidate: false }, password: { ...password, isNotValidate: true } });
+		} else if (!email.value.includes('@') && password.value.length < 8) {
+			setUserAuthForm({ email: { ...email, isNotValidate: true }, password: { ...password, isNotValidate: true } });
+		}
+	};
+
+	const onAuthFormChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		if (!(event.currentTarget instanceof HTMLInputElement)) return;
+
+		const { name, value } = event.currentTarget;
+
+		if (name === 'email') {
+			const newUserAuthForm = { ...userAuthForm, [name]: { value, isNotValidate: userAuthForm.email.isNotValidate } };
+			setUserAuthForm(newUserAuthForm);
+			userAuthFormValidation(newUserAuthForm);
+		}
+		if (name === 'password') {
+			const newUserInfoForm = {
+				...userAuthForm,
+				[name]: { value, isNotValidate: userAuthForm.password.isNotValidate },
+			};
+			setUserAuthForm(newUserInfoForm);
+			userAuthFormValidation(newUserInfoForm);
+		}
+	};
+
+	const onAuthFormSubmitClick = (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		props.onAuthFormSubmit({ email: userAuthForm.email.value, password: userAuthForm.password.value });
+	};
+
+	return { userAuthForm, onAuthFormChange, onAuthFormSubmitClick };
+};
+
+export default useAuthForm;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,14 @@
+// Layout Component
+export { default as Layout } from './layout';
+
+// Shared Components
+export { default as Input } from './shared/Input';
+export { default as Button } from './shared/Button';
+
+// Feature Components
+export { default as AuthForm } from './feature/AuthForm';
+export { default as TodoInputForm } from './feature/TodoInputForm';
+export { default as TodoItem } from './feature/TodoItem';
+
+// Only Styled Component
+export { default as FlexBox } from './layout/styled';

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+
+const Layout = (props: PropsWithChildren) => {
+	return <>{props.children}</>;
+};
+
+export default Layout;

--- a/src/components/layout/styled.ts
+++ b/src/components/layout/styled.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+type FlexBoxProps = {
+	flexDirection?: 'row' | 'column';
+	alignItem?: 'normal' | 'strech' | 'center' | 'start' | 'end' | 'flex-start' | 'flex-end' | 'baseline';
+	justifyContent?:
+		| 'normal'
+		| 'strech'
+		| 'center'
+		| 'start'
+		| 'end'
+		| 'flex-start'
+		| 'flex-end'
+		| 'space-between'
+		| 'space-around'
+		| 'space-evenly';
+};
+
+export const FlexBox = styled.div<FlexBoxProps>`
+	display: flex;
+	flex-direction: ${({ flexDirection }) => flexDirection && flexDirection};
+	align-items: ${({ alignItem }) => alignItem && alignItem};
+	justify-content: ${({ justifyContent }) => justifyContent && justifyContent};
+`;
+
+export default FlexBox;

--- a/src/components/shared/Button/index.tsx
+++ b/src/components/shared/Button/index.tsx
@@ -1,0 +1,15 @@
+import * as S from './styled';
+import { PropsWithChildren } from 'react';
+
+type Props = {
+	type: 'button' | 'submit';
+	disabled?: boolean;
+	backgroundColor?: string;
+	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+} & PropsWithChildren;
+
+const Button = ({ children, ...props }: Props) => {
+	return <S.Button {...props}>{children}</S.Button>;
+};
+
+export default Button;

--- a/src/components/shared/Button/styled.ts
+++ b/src/components/shared/Button/styled.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Button = styled.button<{ backgroundColor?: string }>`
+	margin: 0;
+	padding: 0.5em 0;
+	border: none;
+	background-color: ${({ backgroundColor, theme }) => (backgroundColor ? backgroundColor : theme.colors.primary)};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	font-weight: ${({ theme }) => theme.fontWeights.strongBold};
+	color: ${({ theme }) => theme.colors.white};
+	cursor: pointer;
+
+	&:disabled {
+		opacity: 0.7;
+		cursor: not-allowed;
+	}
+`;

--- a/src/components/shared/Input/index.tsx
+++ b/src/components/shared/Input/index.tsx
@@ -1,0 +1,16 @@
+import * as S from './styled';
+
+type Props = {
+	id?: string;
+	type: 'text' | 'password';
+	value?: string;
+	name?: string;
+	placeholder: string;
+	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const Input = (props: Props) => {
+	return <S.Input {...props} />;
+};
+
+export default Input;

--- a/src/components/shared/Input/styled.ts
+++ b/src/components/shared/Input/styled.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const InputWrapper = styled.div<{ margin?: string }>`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+	margin: ${({ margin }) => margin && margin};
+`;
+
+export const Input = styled.input`
+	width: 100%;
+	padding: 0.5em;
+	border: 1px solid ${({ theme }) => theme.colors.primary};
+	border-radius: 0;
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+`;
+
+export const InputLabel = styled.label`
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	font-weight: ${({ theme }) => theme.fontWeights.semiBold};
+`;
+
+export const InputErrorMessage = styled.span`
+	font-size: ${({ theme }) => theme.fontSizes.small};
+	color: ${({ theme }) => theme.colors.red};
+`;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,15 @@
+export const GET = 'GET';
+export const POST = 'POST';
+export const PUT = 'PUT';
+export const DELETE = 'DELETE';
+
+export const PATH = {
+	auth: {
+		index: '/auth',
+		signin: '/signin',
+		signup: '/signup',
+	},
+	todos: {
+		index: '/todos',
+	},
+};

--- a/src/constants/error.ts
+++ b/src/constants/error.ts
@@ -1,0 +1,14 @@
+export const AUTH_INPUT_ERROR_MESSAGE = {
+	email: "이메일에 '@'을 포함해야 합니다.",
+	password: '비밀번호는 8자 이상 입력해야 합니다.',
+};
+
+export const API_ERROR_MESSAGE = {
+	signin: {
+		unauthorized: 'Unauthorized',
+		notEnrolledMember: '해당 사용자가 존재하지 않습니다.',
+	},
+	signup: {
+		existingMember: '동일한 이메일이 이미 존재합니다.',
+	},
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<React.StrictMode>
-		<App />
+		<BrowserRouter>
+			<App />
+		</BrowserRouter>
 	</React.StrictMode>,
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import { GlobalStyle, theme } from './styles';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<React.StrictMode>
-		<BrowserRouter>
-			<App />
-		</BrowserRouter>
+		<ThemeProvider theme={theme}>
+			<BrowserRouter>
+				<GlobalStyle />
+				<App />
+			</BrowserRouter>
+		</ThemeProvider>
 	</React.StrictMode>,
 );

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -1,0 +1,5 @@
+const Auth = () => {
+	return <div>Auth Page</div>;
+};
+
+export default Auth;

--- a/src/pages/Auth/index.tsx
+++ b/src/pages/Auth/index.tsx
@@ -1,5 +1,28 @@
+import * as S from './styled';
+import { Layout, AuthForm } from '../../components';
+import useAuth from './useAuth';
+
 const Auth = () => {
-	return <div>Auth Page</div>;
+	const { mode, setMode, onSignInFormSubmit, onSignUpFormSubmit } = useAuth();
+
+	return (
+		<Layout>
+			<S.Container>
+				<S.InnerContainer>
+					<S.ModeButtonWrapper>
+						<S.ModeButton type="button" active={mode === 'signin'} onClick={() => setMode('signin')}>
+							로그인
+						</S.ModeButton>
+						<S.ModeButton type="button" active={mode === 'signup'} onClick={() => setMode('signup')}>
+							회원가입
+						</S.ModeButton>
+					</S.ModeButtonWrapper>
+					{mode === 'signin' && <AuthForm mode={mode} onAuthFormSubmit={onSignInFormSubmit} />}
+					{mode === 'signup' && <AuthForm mode={mode} onAuthFormSubmit={onSignUpFormSubmit} />}
+				</S.InnerContainer>
+			</S.Container>
+		</Layout>
+	);
 };
 
 export default Auth;

--- a/src/pages/Auth/styled.ts
+++ b/src/pages/Auth/styled.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const Container = styled.main`
+	${({ theme }) => theme.layout.flexCenter};
+`;
+
+export const InnerContainer = styled.div`
+	${({ theme }) => theme.layout.flexColumn};
+	width: 50vw;
+	background-color: ${({ theme }) => theme.colors.white};
+`;
+
+export const ModeButtonWrapper = styled.div`
+	display: flex;
+`;
+
+export const ModeButton = styled.button<{ active: boolean }>`
+	flex: 1;
+	padding: 0.5em 0;
+	border: 1px solid ${({ theme }) => theme.colors.primary};
+	background: ${({ active, theme }) => (active ? theme.colors.primary : theme.colors.white)};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	font-weight: ${({ active, theme }) => (active ? theme.fontWeights.bold : theme.fontWeights.normal)};
+	color: ${({ active, theme }) => (active ? theme.colors.white : theme.colors.black)};
+`;

--- a/src/pages/Auth/useAuth.ts
+++ b/src/pages/Auth/useAuth.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AxiosError } from 'axios';
+import { signin, signup } from '../../apis/auth';
+import { UserAuthRequestDto } from '../../types/auth';
+import { getLocalStorageItem, KEYS, setLocalStorageItem } from '../../utils/storage';
+import { API_ERROR_MESSAGE } from '../../constants/error';
+
+const useAuth = () => {
+	const navigator = useNavigate();
+	const [mode, setMode] = useState<'signin' | 'signup'>('signin');
+
+	const onSignInFormSubmit = async (userAuthRequestBody: UserAuthRequestDto) => {
+		try {
+			const accessToken = await signin(userAuthRequestBody);
+			setLocalStorageItem(KEYS.WANTED_ACCESS_TOKEN, accessToken);
+			navigator('/todo');
+		} catch (error) {
+			if (error instanceof AxiosError && error.response?.data.message === API_ERROR_MESSAGE.signin.notEnrolledMember) {
+				alert('존재하지 않는 계정입니다.');
+			}
+			if (error instanceof AxiosError && error.response?.data.message === API_ERROR_MESSAGE.signin.unauthorized) {
+				alert('비밀번호가 일치하지 않습니다.');
+			}
+		}
+	};
+
+	const onSignUpFormSubmit = async (userAuthRequestBody: UserAuthRequestDto) => {
+		try {
+			const accessToken = await signup(userAuthRequestBody);
+			setLocalStorageItem(KEYS.WANTED_ACCESS_TOKEN, accessToken);
+			navigator('/todo');
+		} catch (error) {
+			if (error instanceof AxiosError && error.response?.data.message === API_ERROR_MESSAGE.signup)
+				alert('이미 존재하는 계정입니다.');
+		}
+	};
+
+	useEffect(() => {
+		if (getLocalStorageItem(KEYS.WANTED_ACCESS_TOKEN)) {
+			navigator('/todo');
+		}
+	}, []);
+
+	return { mode, setMode, onSignInFormSubmit, onSignUpFormSubmit };
+};
+
+export default useAuth;

--- a/src/pages/Todo/index.tsx
+++ b/src/pages/Todo/index.tsx
@@ -1,0 +1,5 @@
+const Todo = () => {
+	return <div>Todo Page</div>;
+};
+
+export default Todo;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,2 @@
+export { default as Auth } from './Auth';
+export { default as Todo } from './Todo';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,0 +1,13 @@
+import { Routes, Route } from 'react-router-dom';
+import { Auth, Todo } from '../pages';
+
+const Router = () => {
+	return (
+		<Routes>
+			<Route path="/" element={<Auth />} />
+			<Route path="/todo" element={<Todo />} />
+		</Routes>
+	);
+};
+
+export default Router;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -1,6 +1,9 @@
 import * as styled from 'styled-components';
+import reset from 'styled-reset';
 
 const GlobalStyle = styled.createGlobalStyle`
+	${reset}
+
 	*,
 	*::before,
 	*::after {

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -1,0 +1,11 @@
+import * as styled from 'styled-components';
+
+const GlobalStyle = styled.createGlobalStyle`
+	*,
+	*::before,
+	*::after {
+		box-sizing: border-box;
+	}
+`;
+
+export default GlobalStyle;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,2 @@
+export { default as GlobalStyle } from './GlobalStyle';
+export { default as theme } from './theme';

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -3,9 +3,18 @@ import 'styled-components';
 declare module 'styled-components' {
 	export interface DefaultTheme {
 		fontSizes: {
-			title: string;
-			subTitle: string;
-			paragraph: string;
+			small: string;
+			normal: string;
+			medium: string;
+			large: string;
+		};
+		fontWeights: {
+			light: 300;
+			normal: 400;
+			medium: 500;
+			semiBold: 600;
+			bold: 700;
+			strongBold: 800;
 		};
 		colors: {
 			black: '#000000';
@@ -15,6 +24,11 @@ declare module 'styled-components' {
 			green: '#44bd32';
 			blue: '#3498db';
 			primary: '#273c75';
+		};
+		layout: {
+			flexCenter: string;
+			flexColumn: string;
+			flexCenterColumn: string;
 		};
 	}
 }

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -1,0 +1,20 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+	export interface DefaultTheme {
+		fontSizes: {
+			title: string;
+			subTitle: string;
+			paragraph: string;
+		};
+		colors: {
+			black: '#000000';
+			white: '#FFFFFF';
+			yellow: '#fbc531';
+			red: '#e74c3c';
+			green: '#44bd32';
+			blue: '#3498db';
+			primary: '#273c75';
+		};
+	}
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,9 +4,18 @@ const pixelToRem = (size: number) => `${size / 16}rem`;
 
 const theme: DefaultTheme = {
 	fontSizes: {
-		title: pixelToRem(60),
-		subTitle: pixelToRem(30),
-		paragraph: pixelToRem(18),
+		small: pixelToRem(12),
+		normal: pixelToRem(16),
+		medium: pixelToRem(20),
+		large: pixelToRem(24),
+	},
+	fontWeights: {
+		light: 300,
+		normal: 400,
+		medium: 500,
+		semiBold: 600,
+		bold: 700,
+		strongBold: 800,
 	},
 	colors: {
 		black: '#000000',
@@ -16,6 +25,23 @@ const theme: DefaultTheme = {
 		green: '#44bd32',
 		blue: '#3498db',
 		primary: '#273c75',
+	},
+	layout: {
+		flexCenter: `
+			display: flex;
+   	 	justify-contents: center;
+    	align-items: center;
+		`,
+		flexColumn: `
+			display: flex;
+    	flex-direction: column;
+		`,
+		flexCenterColumn: `
+			display: flex;
+    	flex-direction: column;
+    	justify-contents: center;
+    	align-items: center;
+		`,
 	},
 };
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,22 @@
+import { DefaultTheme } from 'styled-components';
+
+const pixelToRem = (size: number) => `${size / 16}rem`;
+
+const theme: DefaultTheme = {
+	fontSizes: {
+		title: pixelToRem(60),
+		subTitle: pixelToRem(30),
+		paragraph: pixelToRem(18),
+	},
+	colors: {
+		black: '#000000',
+		white: '#FFFFFF',
+		yellow: '#fbc531',
+		red: '#e74c3c',
+		green: '#44bd32',
+		blue: '#3498db',
+		primary: '#273c75',
+	},
+};
+
+export default theme;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,19 @@
+export type UserAuthRequestDto = {
+	email: string;
+	password: string;
+};
+
+export type UserAuthResponseDto = {
+	access_token: string;
+};
+
+export type UserAuthForm = {
+	email: {
+		value: string;
+		isNotValidate: boolean;
+	};
+	password: {
+		value: string;
+		isNotValidate: boolean;
+	};
+};

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,0 +1,6 @@
+export type Todo = {
+	id: number;
+	todo: string;
+	isCompleted: boolean;
+	userId: number;
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,29 @@
+const EMPTY_VALIE = '';
+export const KEYS = {
+	WANTED_ACCESS_TOKEN: 'WANTED_ACCESS_TOKEN',
+};
+
+export const getLocalStorageItem = (key: string): any => {
+	try {
+		const item = localStorage.getItem(key);
+		return item ? JSON.parse(item) : EMPTY_VALIE;
+	} catch (error) {
+		throw new Error(`로컬 스토리지 데이터 가져오기 에러: ${error}`);
+	}
+};
+
+export const setLocalStorageItem = (key: string, value: any) => {
+	try {
+		localStorage.setItem(key, JSON.stringify(value));
+	} catch (error) {
+		throw new Error(`로컬 스토리지 값 저장 에러: ${error}`);
+	}
+};
+
+export const removeLocalStorageItem = (key: string) => {
+	try {
+		localStorage.removeItem(key);
+	} catch (error) {
+		throw new Error(`로컬 스토리지 값 삭제 에러: ${error}`);
+	}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,6 +635,20 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.1.3.tgz#8274250dada2edf53814ed7db644b9c2866c1e35"
+  integrity sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 "babel-plugin-styled-components@>= 1.12.0":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
@@ -785,6 +799,13 @@ colorette@^2.0.16, colorette@^2.0.17:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^9.3.0:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
@@ -861,6 +882,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1414,6 +1440,20 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1917,6 +1957,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2186,6 +2238,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -2519,6 +2576,11 @@ styled-components@^5.3.6:
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
+
+styled-reset@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-4.4.2.tgz#4da1becb2f6d22a2b22c7ee7ca09b739fe6a685f"
+  integrity sha512-VzVhEZHpO/CD/F5ZllqTAY+GTaKlNDZt5mTrtPf/kXZSe85+wMkhRIiPARgvCP9/HQMk+ZGaEWk1IkdP2SYAUQ==
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
## 해결한 이슈

- #1
- #2 
- #3 

<br />

## 해결 방법

Assignment 1-1 - 로그인/회원가입 페이지 스타일링 & 이메일과 비밀번호의 유효성 검사기능 구현

`로그인 - 회원가입 페이지 간 전환`

- 로그인 / 회원가입 페이지간 전환은 설계한 UI 형태상 페이지 제목과 버튼 텍스트 정도만 다르기 때문에 라우팅을 따로 하지 않음.
- 대신, `mode` 라는 이름의 상태 값으로 로그인 - 회원가입 페이지 간의 화면 전환을 구현.

`이메일 & 비밀번호 유효성 검사 기능`

- 이메일, 비밀번호에 대한 상태 값 하나의 객체 state 로 관리.
- 이메일, 비밀번호 각각은 또한 { value, isNotValidate } 속성을 가지는 객체.
- 각 입력 타겟에 대에 onChange 이벤트가 발생할 때마다 입력 타겟의 상태값을 업데이트하면서, 유효성 검사 함수도 함께 진행.
- 각 입력에 대해 유효성 검사가 만족하면 helper message 가 사라지고 이메일, 비밀번호 유효성이 모두 만족하면 로그인 or 회원가입 버튼이 활성화 되도록 진행.
- 컴포넌트 내에 선언된 이러한 로직을 커스텀 훅인 `useAuthForm` 로 분리하고 view 에서 호출하여 사용.

Assignment 1-2 - 로그인 API 정의 & 로그인 성공 후 투두 앱으로 라우팅

- 각 도메인 API 메서드 정의 이전에 Http Client Instance 생성 모듈인 requester 모듈을 정의.
- API 관련 모듈은 `src/apis` 에서 관리.
- 로그인 / 회원가입에 관한 API 는 `src/apis/auth.ts` 에서 정의하여 사용.
- 로그인 or 회원가입이 진행되고 나서 성공했다면 투두 앱 페이지로 라우팅 처리.
- 이 또한 컴포넌트 내에 선언된 로직을 커스텀 훅인 `useAuth` 로 분리하고 view 에서 호출하여 사용. 

Assignment 1-3 - 로그인 여부에 따른 리다이렉팅

- 로그인 토큰에 따라 리다이렉팅을 체크해야하는 페이지는 현재 요구사항에서는 Auth 페이지는 필요없고 Todo 페이지만 필요.
  - Todo 페이지만 JWT 토큰 유무에 따른 의존성이 걸려 있기 때문.
- 따라서, 과제 요구사항에 따라 LocalStorage 에 JWT 가 있는지 useEffect hooks 에서 초기 렌더링 시에 체크하고 없다면 Auth 페이지로 리다이렉팅.

<br />


## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
