### PR TITLE
[#4][#5] 투투 리스트 페이지 요구사항 구현

### DIFF
--- a/src/components/feature/TodoInputForm/index.tsx
+++ b/src/components/feature/TodoInputForm/index.tsx
@@ -1,0 +1,24 @@
+import * as S from './styled';
+import { Input, Button } from '../../';
+import useTodoInputForm from './useTodoInputForm';
+
+type Props = {
+	onCreateNewTodoSubmit: (newTodo: string) => void;
+};
+
+const TodoInputForm = (props: Props) => {
+	const { newTodo, handleNewTodoInput, handleCreateNewTodoSubmit } = useTodoInputForm({
+		onCreateNewTodoSubmit: props.onCreateNewTodoSubmit,
+	});
+
+	return (
+		<S.TodoInputForm onSubmit={handleCreateNewTodoSubmit}>
+			<Input type="text" placeholder="할 일을 입력하세요." value={newTodo} onChange={handleNewTodoInput} />
+			<Button type="submit" disabled={!newTodo}>
+				추가
+			</Button>
+		</S.TodoInputForm>
+	);
+};
+
+export default TodoInputForm;

--- a/src/components/feature/TodoInputForm/styled.ts
+++ b/src/components/feature/TodoInputForm/styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const TodoInputForm = styled.form`
+	display: flex;
+
+	& > input {
+		flex: 11;
+	}
+
+	& > button {
+		flex: 1;
+		padding: 0 2em;
+	}
+`;

--- a/src/components/feature/TodoInputForm/useTodoInputForm.ts
+++ b/src/components/feature/TodoInputForm/useTodoInputForm.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+type Props = {
+	onCreateNewTodoSubmit: (newTodo: string) => void;
+};
+
+const useTodoInputForm = (props: Props) => {
+	const [newTodo, setNewTodo] = useState('');
+
+	const handleNewTodoInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+		if (!(event.currentTarget instanceof HTMLInputElement)) return;
+		setNewTodo(event.currentTarget.value);
+	};
+
+	const handleCreateNewTodoSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		props.onCreateNewTodoSubmit(newTodo);
+		setNewTodo('');
+	};
+
+	return { newTodo, handleNewTodoInput, handleCreateNewTodoSubmit };
+};
+
+export default useTodoInputForm;

--- a/src/components/feature/TodoItem/index.tsx
+++ b/src/components/feature/TodoItem/index.tsx
@@ -1,0 +1,69 @@
+import * as S from './styled';
+import { Button, Input } from '../../';
+import { theme } from '../../../styles';
+import { Todo } from '../../../types/todo';
+import useTodoItem from './useTodoItem';
+
+type Props = {
+	todo: Todo;
+	onTodoCompletedToggle: (targetTodo: Todo) => void;
+	onTodoItemEdit: (targetTodo: Todo, newTodo: string) => void;
+	onTodoItemDelete: (targetTodo: Todo) => void;
+};
+
+const TodoItem = (props: Props) => {
+	const {
+		isEditMode,
+		todo,
+		onTodoItemCompletedButtonClick,
+		onIsEditModeToggle,
+		onTodoItemChange,
+		onTodoItemEditSubmitClick,
+		onTodoItemDeleteButtonClick,
+	} = useTodoItem({
+		todo: props.todo,
+		onTodoCompletedToggle: props.onTodoCompletedToggle,
+		onTodoItemEdit: props.onTodoItemEdit,
+		onTodoItemDelete: props.onTodoItemDelete,
+	});
+
+	return (
+		<S.Container isEditMode={isEditMode}>
+			{!isEditMode && (
+				<S.TodoItemCompletedWrapper>
+					<Button type="button" backgroundColor={theme.colors.yellow} onClick={onTodoItemCompletedButtonClick}>
+						{props.todo.isCompleted ? '✅' : '🚴🏻‍♂️'}
+					</Button>
+				</S.TodoItemCompletedWrapper>
+			)}
+			{isEditMode ? (
+				<S.TodoItemContentWrapper>
+					<Input type="text" placeholder="할 일을 채워주세요." value={todo} onChange={onTodoItemChange} />
+				</S.TodoItemContentWrapper>
+			) : (
+				<S.TodoItemContentWrapper>{props.todo.todo}</S.TodoItemContentWrapper>
+			)}
+			{isEditMode ? (
+				<S.TodoItemButtonWrapper>
+					<Button type="button" onClick={onIsEditModeToggle}>
+						취소
+					</Button>
+					<Button type="button" backgroundColor={theme.colors.green} onClick={onTodoItemEditSubmitClick}>
+						제출
+					</Button>
+				</S.TodoItemButtonWrapper>
+			) : (
+				<S.TodoItemButtonWrapper>
+					<Button type="button" onClick={onIsEditModeToggle}>
+						수정
+					</Button>
+					<Button type="button" backgroundColor={theme.colors.red} onClick={onTodoItemDeleteButtonClick}>
+						삭제
+					</Button>
+				</S.TodoItemButtonWrapper>
+			)}
+		</S.Container>
+	);
+};
+
+export default TodoItem;

--- a/src/components/feature/TodoItem/styled.ts
+++ b/src/components/feature/TodoItem/styled.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+export const Container = styled.li<{ isEditMode: boolean }>`
+	display: flex;
+	border: 1px solid ${({ theme }) => theme.colors.black};
+
+	& > div:nth-of-type(1) {
+		flex: ${({ isEditMode }) => (isEditMode ? 10 : 1)};
+	}
+
+	& > div:nth-of-type(2) {
+		flex: ${({ isEditMode }) => (isEditMode ? 2 : 9)};
+		margin-left: ${({ isEditMode }) => !isEditMode && '0.75em'};
+	}
+
+	& > div:nth-of-type(3) {
+		flex: ${({ isEditMode }) => !isEditMode && 2};
+	}
+`;
+
+export const TodoItemCompletedWrapper = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	& > button {
+		flex: 1;
+	}
+`;
+
+export const TodoItemContentWrapper = styled.div`
+	display: flex;
+	align-items: center;
+	width: 100%;
+`;
+
+export const TodoItemButtonWrapper = styled.div`
+	display: flex;
+
+	& > button {
+		flex: 1;
+	}
+`;

--- a/src/components/feature/TodoItem/useTodoItem.ts
+++ b/src/components/feature/TodoItem/useTodoItem.ts
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Todo } from '../../../types/todo';
+
+type Props = {
+	todo: Todo;
+	onTodoCompletedToggle: (targetTodo: Todo) => void;
+	onTodoItemEdit: (targetTodo: Todo, newTodo: string) => void;
+	onTodoItemDelete: (targetTodo: Todo) => void;
+};
+
+const useTodoItem = (props: Props) => {
+	const [isEditMode, setIsEditMode] = useState(false);
+	const [todo, setTodo] = useState(props.todo.todo);
+
+	const onTodoItemCompletedButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		props.onTodoCompletedToggle(props.todo);
+	};
+
+	const onIsEditModeToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+		setIsEditMode(!isEditMode);
+	};
+
+	const onTodoItemChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setTodo(event.currentTarget.value);
+	};
+
+	const onTodoItemEditSubmitClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		props.onTodoItemEdit(props.todo, todo);
+		setIsEditMode(!isEditMode);
+	};
+
+	const onTodoItemDeleteButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+		props.onTodoItemDelete(props.todo);
+	};
+
+	return {
+		isEditMode,
+		todo,
+		onTodoItemCompletedButtonClick,
+		onIsEditModeToggle,
+		onTodoItemChange,
+		onTodoItemEditSubmitClick,
+		onTodoItemDeleteButtonClick,
+	};
+};
+
+export default useTodoItem;

--- a/src/pages/Todo/index.tsx
+++ b/src/pages/Todo/index.tsx
@@ -1,5 +1,31 @@
-const Todo = () => {
-	return <div>Todo Page</div>;
+import * as S from './styled';
+import Layout from '../../components/layout';
+import { TodoInputForm, TodoItem } from '../../components';
+import useTodos from './useTodos';
+
+const TodoApp = () => {
+	const { todos, onCreateNewTodoSubmit, onTodoCompletedToggle, onTodoItemEdit, onTodoItemDelete } = useTodos();
+
+	return (
+		<Layout>
+			<S.Container>
+				<TodoInputForm onCreateNewTodoSubmit={onCreateNewTodoSubmit} />
+				{todos.length >= 0 && (
+					<S.TodoList>
+						{todos.map((todo) => (
+							<TodoItem
+								key={todo.id}
+								todo={todo}
+								onTodoCompletedToggle={onTodoCompletedToggle}
+								onTodoItemEdit={onTodoItemEdit}
+								onTodoItemDelete={onTodoItemDelete}
+							/>
+						))}
+					</S.TodoList>
+				)}
+			</S.Container>
+		</Layout>
+	);
 };
 
-export default Todo;
+export default TodoApp;

--- a/src/pages/Todo/styled.ts
+++ b/src/pages/Todo/styled.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const Container = styled.main`
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	min-height: 100vh;
+	padding: 0 2em;
+`;
+
+export const TodoList = styled.ul`
+	display: flex;
+	flex-direction: column;
+	gap: 0.1em;
+	max-height: 77vh;
+	margin-top: 0.5em;
+	overflow: scroll;
+`;

--- a/src/pages/Todo/useTodos.ts
+++ b/src/pages/Todo/useTodos.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createTodo, deleteTodo, getTodos, updateTodo } from '../../apis/todo';
+import { Todo } from '../../types/todo';
+import { getLocalStorageItem, KEYS } from '../../utils/storage';
+
+const useTodos = () => {
+	const navigator = useNavigate();
+	const [todos, setTodos] = useState<Todo[]>([]);
+
+	const onGetTodos = async () => {
+		try {
+			const { data: todos } = await getTodos();
+			setTodos(todos);
+		} catch (error) {
+			console.error('Get Todos Error !');
+		}
+	};
+
+	const onCreateNewTodoSubmit = async (newTodo: string) => {
+		try {
+			await createTodo(newTodo);
+			await onGetTodos();
+		} catch (error) {
+			console.error('Create Todo Error !');
+		}
+	};
+
+	const onTodoCompletedToggle = async (targetTodo: Todo) => {
+		try {
+			await updateTodo(targetTodo);
+			await onGetTodos();
+		} catch (error) {
+			console.error('Update Todo Completed Error !');
+		}
+	};
+
+	const onTodoItemEdit = async (targetTodo: Todo, newTodo: string) => {
+		try {
+			await updateTodo(targetTodo, newTodo);
+			await onGetTodos();
+		} catch (error) {
+			console.error('Update Todo Content Error !');
+		}
+	};
+
+	const onTodoItemDelete = async (targetTodo: Todo) => {
+		try {
+			await deleteTodo(targetTodo);
+			await onGetTodos();
+		} catch (error) {
+			console.error('Delete Todo Error !');
+		}
+	};
+
+	useEffect(() => {
+		if (!getLocalStorageItem(KEYS.WANTED_ACCESS_TOKEN)) {
+			navigator('/');
+		} else {
+			onGetTodos();
+		}
+	}, []);
+
+	return { todos, onCreateNewTodoSubmit, onTodoCompletedToggle, onTodoItemEdit, onTodoItemDelete };
+};
+
+export default useTodos;


### PR DESCRIPTION
## 해결한 이슈

- #4 
- #5 

<br />

## 해결 방법

Assignment 1-4 - 투두 리스트 스타일링 & 투두 아이템 생성

- UI는 사전에 재사용 가능하도록 생성한 `Input, Button` 컴포넌트를 사용하고, 이들을 커스텀한 폼 안에 넣어 구현.
- 새로운 Todo 입력과 추가 버튼에 대한 이벤트 핸들러, 현재 입력 중인 추가할 Todo 내용에 대한 로직을 `useTodoInputForm` 커스텀 훅으로 분리.
- 현재 입력 중인 Todo 내용 유무에 따라 추가 버튼 `비활성화(disabled) 제어` 
- Todo 추가 버튼을 누르면 담당 이벤트 핸들러 내부에 있는 `onCreateNewTodoSubmit` 메서드가 호출되어 새로운 Todo 가 추가된 리스트를 새로 `onGetTodo` 한다.
- 새로운 Todos 아이템에 대해 `리렌더링` 이 이뤄지므로써 새로운 Todo 가 추가된 투두 리스트를 확인. 

Assignment 1-5 - 투두 아이템 수정, 삭제

- 각 Todo Item 에 대해 `수정 모드` 가 있다고 요구사항에 있음.
- 이를 수정 off 모드일 때 Todo Item 과, 수정 on 모드일 때 Todo Item 컴포넌트로 분리해서 사용할까 고민.
- 결론적으로으로 분리하지 않고, `isEditMode` 상태에 따라 `완료 여부, 기존 Todo 내용 수정 입력 컴포넌트, 수정 모드일 때 버튼 컴포넌트` 를 `조건부 렌더링(Conditional Rendering)` 처리해서 구현.
- 수정, 삭제에 대한 처리는 `useTodoItem` 커스텀 훅에서 처리.
  - 실제 API 호출에 대한 것은 부모 컴포넌트에서 props 로 넘겨준 수정, 삭제에 대한 메서드들을 호출해서 처리.
- 수정 or 삭제에 대한 처리가 끝난 후에도 역시 반영된 새로운 투두 리스트를 보여주기 위해 `onGetTodo` 를 호출해서 `todos` 상태를 업데이트해서 리렌더링 필요.

<br />

## 추가적인 태스크

- [ ] 생각해보니 새로운 Todo 입력 컴포넌트에 대해서는 `제어 컴포넌트(Controlled Component)` 방식을 취하고 있지 않아도 된다. 따라서 `비제어 컴포넌트(Uncontrolled Component)` 방식으로 변경하거나 `디바운스(Debounce)` 를 이용해 불필요한 리렌더링을 방지하는 것이 성능 차원에서 좋겠다.

<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
